### PR TITLE
refactor: getDayOffBootFlg() を削除し getTagValue() に統一する

### DIFF
--- a/app.js
+++ b/app.js
@@ -97,17 +97,6 @@ function getNow() {
     return moment().utcOffset("+09:00");
 }
 
-function getDayOffBootFlg(instance, tagName){
-    let tagValue = "";
-    if (instance.Tags) {
-        instance.Tags.forEach(function (tag) {
-            if (tag.Key === tagName) tagValue = tag.Value;
-        });
-    }
-    console.log(tagName + " = " + tagValue);
-    return tagValue;
-}
-
 function getTagValue(instance, tagName) {
     let tagValue = "";
     if (instance.Tags) {
@@ -250,7 +239,8 @@ export const handler = async (event, context) => {
 
                     const serName = getTagValue(instance, "Name");
                     console.log("check instance(id = " + instance.InstanceId + "(" + serName + ")");
-                    const dayoff = getDayOffBootFlg(instance, "DayOffBoot");
+                    const dayoff = getTagValue(instance, "DayOffBoot");
+                    console.log("DayOffBoot = " + dayoff);
                     const start = getDateValue(instance, "AutoStart", nowhhmm, dayoff);
                     const end = getDateValue(instance, "AutoStop", nowhhmm);
                     


### PR DESCRIPTION
## 概要

`getDayOffBootFlg()` と `getTagValue()` が同一実装になっており重複していたため、`getDayOffBootFlg()` を削除し、呼び出し側で `getTagValue()` を使うよう統一しました。

## 変更内容

- `getDayOffBootFlg()` 関数を削除
- `handler` 内の呼び出しを `getTagValue(instance, "DayOffBoot")` に変更
- ログ出力 (`console.log`) を呼び出し側で明示

## 動作確認

- `DayOffBoot` タグの取得挙動は変わらない
- タグ取得ロジックが `getTagValue()` に一本化された

Closes #856

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how instance tag values are read and reported, making the output more consistent during instance processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->