### PR TITLE
robustness: インスタンス単位で try/catch し全体停止を防ぐ

### DIFF
--- a/app.js
+++ b/app.js
@@ -234,25 +234,29 @@ export const handler = async (event, context) => {
                 const instances = res.Instances;
                 if (!instances) continue;
                 for (const instance of instances) {
-                    const instanceID = instance.InstanceId;
-                    console.log("instance " + instanceID);
+                    try {
+                        const instanceID = instance.InstanceId;
+                        console.log("instance " + instanceID);
 
-                    const serName = getTagValue(instance, "Name");
-                    console.log("check instance(id = " + instance.InstanceId + "(" + serName + ")");
-                    const dayoff = getTagValue(instance, "DayOffBoot");
-                    console.log("DayOffBoot = " + dayoff);
-                    const start = getDateValue(instance, "AutoStart", nowhhmm, dayoff);
-                    const end = getDateValue(instance, "AutoStop", nowhhmm);
-                    
-                    if (start !== "" && end !== "") {
-                        const result = handleInstance(instance.State.Name, start, end, nowhhmm);
-                        if (result === "start") {
-                            await startInstance(instance.InstanceId);
-                        } else if (result === "stop") {
-                            await stopInstance(instance.InstanceId);
-                        } else {
-                            console.log("check handleInstance(message) = " + result + ")");
+                        const serName = getTagValue(instance, "Name");
+                        console.log("check instance(id = " + instance.InstanceId + "(" + serName + ")");
+                        const dayoff = getTagValue(instance, "DayOffBoot");
+                        console.log("DayOffBoot = " + dayoff);
+                        const start = getDateValue(instance, "AutoStart", nowhhmm, dayoff);
+                        const end = getDateValue(instance, "AutoStop", nowhhmm);
+
+                        if (start !== "" && end !== "") {
+                            const result = handleInstance(instance.State.Name, start, end, nowhhmm);
+                            if (result === "start") {
+                                await startInstance(instance.InstanceId);
+                            } else if (result === "stop") {
+                                await stopInstance(instance.InstanceId);
+                            } else {
+                                console.log("check handleInstance(message) = " + result + ")");
+                            }
                         }
+                    } catch (err) {
+                        console.error("instance " + instance.InstanceId + " failed. " + err, err.stack);
                     }
                 }
             }

--- a/app.js
+++ b/app.js
@@ -24,7 +24,6 @@ async function stopInstance(instanceId) {
         await ec2Client.send(command);
         console.log("stop success. instance id = " + instanceId);
     } catch (err) {
-        console.error(err, err.stack);
         throw err;
     }
 }
@@ -39,7 +38,6 @@ async function startInstance(instanceId) {
         await ec2Client.send(command);
         console.log("start success. instance id = " + instanceId);
     } catch (err) {
-        console.error(err, err.stack);
         throw err;
     }
 }
@@ -256,7 +254,7 @@ export const handler = async (event, context) => {
                             }
                         }
                     } catch (err) {
-                        console.error("instance " + instance.InstanceId + " failed. " + err, err.stack);
+                        console.error("instance " + instance.InstanceId + " failed.", err);
                     }
                 }
             }


### PR DESCRIPTION
## 概要

インスタンスループ内で `startInstance()` / `stopInstance()` が失敗した場合でも、他のインスタンスの処理が継続されるようにしました。

## 変更内容

- インスタンス単位で try/catch を追加
- 失敗時は対象インスタンス ID とエラー内容を `console.error` でログに残す
- 外側の try/catch は `DescribeInstances` 等の致命的エラー用として維持

## 動作確認

- 1 件のインスタンスで `startInstance` / `stopInstance` が失敗しても、残りのインスタンスが継続処理される
- エラーは握りつぶさずログに残る

Closes #857