### PR TITLE
robustness: インスタンスエラーを蓄積し Lambda Errors メトリクスに反映する

### DIFF
--- a/app.js
+++ b/app.js
@@ -228,6 +228,7 @@ export const handler = async (event, context) => {
         if (!data.Reservations || data.Reservations.length === 0) {
             console.log("don't find ec2");
         } else {
+            const failedInstances = [];
             for (const res of data.Reservations) {
                 const instances = res.Instances;
                 if (!instances) continue;
@@ -255,10 +256,14 @@ export const handler = async (event, context) => {
                         }
                     } catch (err) {
                         console.error("instance " + instance.InstanceId + " failed.", err);
+                        failedInstances.push(instance.InstanceId);
                     }
                 }
             }
             console.log("-----------------all done.-----------------");
+            if (failedInstances.length > 0) {
+                throw new Error(failedInstances.length + " instance(s) failed: " + failedInstances.join(", "));
+            }
         }
     } catch (err) {
         console.error(err, err.stack);


### PR DESCRIPTION
## 概要

インスタンス単位の try/catch でエラーをキャッチして処理を継続していましたが、`console.error` でログに残すだけでは Lambda の Errors メトリクスにカウントされません。
本 PR では失敗したインスタンス ID を蓄積し、全インスタンス処理後に 1 件でも失敗があれば `throw` して Lambda モニタリングにエラーを反映させます。

## 変更内容

- `failedInstances` 配列でエラー発生インスタンス ID を蓄積
- 全ループ完了後、`failedInstances.length > 0` であれば `Error` を throw
- エラーメッセージに失敗件数と対象インスタンス ID を含める

## 動作確認

- 1 件失敗しても残りのインスタンスは継続処理される
- 1 件でも失敗があれば Lambda の Errors メトリクスに計上される
- CloudWatch アラームでの通知が可能になる

Closes #903

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The app now reports a failed run if any instance-level processing errors occur, instead of only logging them.
  * When failures happen, the final error includes the affected instance IDs, making it easier to identify and retry problematic instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->